### PR TITLE
chore!: changed package path and repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [.benchmarks_sabi](https://github.com/sttk-go/.benchmarks_sabi)
+# [benchmarks_sabi](https://github.com/sttk/benchmarks_sabi-go)
 
 Benchmarks of Sabi modules
 

--- a/dax/sabi_0_4_0/benchmark.md
+++ b/dax/sabi_0_4_0/benchmark.md
@@ -3,7 +3,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	68064441	        17.31 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	13056586	        90.89 ns/op	       0 B/op	       0 allocs/op
@@ -25,5 +25,5 @@ Benchmark_RunTxn_commit_fiveDs-12         	  191404	      6089 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  720508	      1609 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  224719	      5027 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0	25.865s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0	25.865s
 ```

--- a/dax/sabi_0_4_0/benchmark000_AddGlobalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/benchmark000_AddGlobalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_AddGlobalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark010_SetupGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/benchmark010_SetupGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_SetupGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark020_FreeGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/benchmark020_FreeGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_FreeGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark030_NewDaxBase_test.go
+++ b/dax/sabi_0_4_0/benchmark030_NewDaxBase_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_NewDaxBase(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark040_SetupLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/benchmark040_SetupLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_SetupLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark050_FreeLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/benchmark050_FreeLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_FreeLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark060_GetDaxConn_test.go
+++ b/dax/sabi_0_4_0/benchmark060_GetDaxConn_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_GetDaxConn_global_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/benchmark070_RunTxn_test.go
+++ b/dax/sabi_0_4_0/benchmark070_RunTxn_test.go
@@ -1,8 +1,9 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 func Benchmark_RunTxn_commit_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark.md
+++ b/dax/sabi_0_4_0/ready_async/benchmark.md
@@ -5,7 +5,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	298844008	         3.857 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	42650397	        28.20 ns/op	       0 B/op	       0 allocs/op
@@ -27,7 +27,7 @@ Benchmark_RunTxn_commit_fiveDs-12         	  586051	      2031 ns/op	     560 B/
 Benchmark_RunTxn_rollback_oneDs-12        	 2011890	       597.8 ns/op	     384 B/op	       5 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  600097	      1932 ns/op	     512 B/op	      13 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async	27.006s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async	27.006s
 ```
 
 ## unlock
@@ -35,7 +35,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async	27.006s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	297490818	         3.868 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	42367635	        28.44 ns/op	       0 B/op	       0 allocs/op
@@ -57,7 +57,7 @@ Benchmark_RunTxn_commit_fiveDs-12         	  191364	      5997 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  732496	      1594 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  234860	      4922 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.409s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.409s
 ```
 
 ## original
@@ -65,7 +65,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.409s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	68298651	        17.34 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	13002093	        91.55 ns/op	       0 B/op	       0 allocs/op
@@ -87,5 +87,5 @@ Benchmark_RunTxn_commit_fiveDs-12         	  192574	      6071 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  730015	      1607 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  233893	      4991 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0	25.667s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0	25.667s
 ```

--- a/dax/sabi_0_4_0/ready_async/benchmark000_AddGlobalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark000_AddGlobalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_AddGlobalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark010_SetupGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark010_SetupGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_SetupGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark020_FreeGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark020_FreeGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_FreeGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark030_NewDaxBase_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark030_NewDaxBase_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_NewDaxBase(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark040_SetupLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark040_SetupLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_SetupLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark050_FreeLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark050_FreeLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_FreeLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark060_GetDaxConn_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark060_GetDaxConn_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_GetDaxConn_global_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/benchmark070_RunTxn_test.go
+++ b/dax/sabi_0_4_0/ready_async/benchmark070_RunTxn_test.go
@@ -1,8 +1,9 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 func Benchmark_RunTxn_commit_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_async/dax.go
+++ b/dax/sabi_0_4_0/ready_async/dax.go
@@ -53,9 +53,9 @@ type /* error reasons */ (
 // DaxConn is an interface which represents a connection to a data store, and
 // defines methods: Commit, Rollback and Close to work in a tranaction process.
 type DaxConn interface {
-	Commit(wg sync.WaitGroup) Err
+	Commit(wg *sync.WaitGroup) Err
 	Committed() Err
-	Rollback(wg sync.WaitGroup)
+	Rollback(wg *sync.WaitGroup)
 	Close()
 }
 
@@ -68,7 +68,7 @@ type DaxConn interface {
 // and frees this dax source.
 type DaxSrc interface {
 	CreateDaxConn() (DaxConn, Err)
-	SetUp(wg sync.WaitGroup) Err
+	SetUp(wg *sync.WaitGroup) Err
 	Ready() Err
 	End()
 }
@@ -117,7 +117,7 @@ func StartUpGlobalDaxSrcs() Err {
 	var wg sync.WaitGroup
 
 	for name, ds := range globalDaxSrcMap {
-		err := ds.SetUp(wg)
+		err := ds.SetUp(&wg)
 		if err.IsNotOk() {
 			errs[name] = err
 		}
@@ -192,7 +192,7 @@ func (base *daxBaseImpl) SetUpLocalDaxSrc(name string, ds DaxSrc) Err {
 		if !exists {
 			var wg sync.WaitGroup
 
-			err := ds.SetUp(wg)
+			err := ds.SetUp(&wg)
 			if err.IsNotOk() {
 				return err
 			}
@@ -280,7 +280,7 @@ func (base *daxBaseImpl) commit() Err {
 	var wg sync.WaitGroup
 
 	for name, conn := range base.daxConnMap {
-		err := conn.Commit(wg)
+		err := conn.Commit(&wg)
 		if err.IsNotOk() {
 			errs[name] = err
 		}
@@ -306,7 +306,7 @@ func (base *daxBaseImpl) rollback() {
 	var wg sync.WaitGroup
 
 	for _, conn := range base.daxConnMap {
-		conn.Rollback(wg)
+		conn.Rollback(&wg)
 	}
 
 	wg.Wait()

--- a/dax/sabi_0_4_0/ready_async/tool_test.go
+++ b/dax/sabi_0_4_0/ready_async/tool_test.go
@@ -1,13 +1,14 @@
 package ready_async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 	"sync"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_async"
 )
 
 type FooDaxConn struct{}
 
-func (conn FooDaxConn) Commit(wg sync.WaitGroup) sabi.Err {
+func (conn FooDaxConn) Commit(wg *sync.WaitGroup) sabi.Err {
 	wg.Add(1)
 	go func() {
 		wg.Done()
@@ -15,7 +16,7 @@ func (conn FooDaxConn) Commit(wg sync.WaitGroup) sabi.Err {
 	return sabi.Ok()
 }
 func (conn FooDaxConn) Committed() sabi.Err { return sabi.Ok() }
-func (conn FooDaxConn) Rollback(wg sync.WaitGroup) {
+func (conn FooDaxConn) Rollback(wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
 		wg.Done()
@@ -25,7 +26,7 @@ func (conn FooDaxConn) Close() {}
 
 type FooDaxSrc struct{}
 
-func (ds FooDaxSrc) SetUp(wg sync.WaitGroup) sabi.Err {
+func (ds FooDaxSrc) SetUp(wg *sync.WaitGroup) sabi.Err {
 	wg.Add(1)
 	go func() {
 		wg.Done()

--- a/dax/sabi_0_4_0/ready_sync/benchmark.md
+++ b/dax/sabi_0_4_0/ready_sync/benchmark.md
@@ -5,7 +5,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	303900372	         3.817 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	43026807	        28.17 ns/op	       0 B/op	       0 allocs/op
@@ -27,7 +27,7 @@ Benchmark_RunTxn_commit_fiveDs-12         	 1754919	       706.0 ns/op	     400 
 Benchmark_RunTxn_rollback_oneDs-12        	 4347273	       288.4 ns/op	     352 B/op	       3 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	 1744645	       832.0 ns/op	     352 B/op	       3 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync	28.260s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync	28.260s
 ```
 
 ## unlock
@@ -35,7 +35,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync	28.260s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	284710560	         3.892 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	41063665	        28.55 ns/op	       0 B/op	       0 allocs/op
@@ -57,7 +57,7 @@ Benchmark_RunTxn_commit_fiveDs-12         	  192516	      6040 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  737906	      1584 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  240207	      4973 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.188s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.188s
 ```
 
 ## original
@@ -65,7 +65,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.188s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	65324341	        18.39 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	12988143	        92.15 ns/op	       0 B/op	       0 allocs/op
@@ -87,5 +87,5 @@ Benchmark_RunTxn_commit_fiveDs-12         	  192198	      6100 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  725706	      1592 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  235545	      4986 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0	24.756s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0	24.756s
 ```

--- a/dax/sabi_0_4_0/ready_sync/benchmark000_AddGlobalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark000_AddGlobalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_AddGlobalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark010_SetupGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark010_SetupGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_SetupGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark020_FreeGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark020_FreeGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_FreeGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark030_NewDaxBase_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark030_NewDaxBase_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_NewDaxBase(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark040_SetupLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark040_SetupLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_SetupLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark050_FreeLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark050_FreeLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_FreeLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark060_GetDaxConn_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark060_GetDaxConn_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_GetDaxConn_global_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/benchmark070_RunTxn_test.go
+++ b/dax/sabi_0_4_0/ready_sync/benchmark070_RunTxn_test.go
@@ -1,8 +1,9 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 func Benchmark_RunTxn_commit_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/ready_sync/dax.go
+++ b/dax/sabi_0_4_0/ready_sync/dax.go
@@ -53,9 +53,9 @@ type /* error reasons */ (
 // DaxConn is an interface which represents a connection to a data store, and
 // defines methods: Commit, Rollback and Close to work in a tranaction process.
 type DaxConn interface {
-	Commit(wg sync.WaitGroup) Err
+	Commit(wg *sync.WaitGroup) Err
 	Committed() Err
-	Rollback(wg sync.WaitGroup)
+	Rollback(wg *sync.WaitGroup)
 	Close()
 }
 
@@ -68,7 +68,7 @@ type DaxConn interface {
 // and frees this dax source.
 type DaxSrc interface {
 	CreateDaxConn() (DaxConn, Err)
-	SetUp(wg sync.WaitGroup) Err
+	SetUp(wg *sync.WaitGroup) Err
 	Ready() Err
 	End()
 }
@@ -117,7 +117,7 @@ func StartUpGlobalDaxSrcs() Err {
 	var wg sync.WaitGroup
 
 	for name, ds := range globalDaxSrcMap {
-		err := ds.SetUp(wg)
+		err := ds.SetUp(&wg)
 		if err.IsNotOk() {
 			errs[name] = err
 		}
@@ -192,7 +192,7 @@ func (base *daxBaseImpl) SetUpLocalDaxSrc(name string, ds DaxSrc) Err {
 		if !exists {
 			var wg sync.WaitGroup
 
-			err := ds.SetUp(wg)
+			err := ds.SetUp(&wg)
 			if err.IsNotOk() {
 				return err
 			}
@@ -280,7 +280,7 @@ func (base *daxBaseImpl) commit() Err {
 	var wg sync.WaitGroup
 
 	for name, conn := range base.daxConnMap {
-		err := conn.Commit(wg)
+		err := conn.Commit(&wg)
 		if err.IsNotOk() {
 			errs[name] = err
 		}
@@ -306,7 +306,7 @@ func (base *daxBaseImpl) rollback() {
 	var wg sync.WaitGroup
 
 	for _, conn := range base.daxConnMap {
-		conn.Rollback(wg)
+		conn.Rollback(&wg)
 	}
 
 	wg.Wait()

--- a/dax/sabi_0_4_0/ready_sync/tool_test.go
+++ b/dax/sabi_0_4_0/ready_sync/tool_test.go
@@ -1,22 +1,23 @@
 package ready_sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 	"sync"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/ready_sync"
 )
 
 type FooDaxConn struct{}
 
-func (conn FooDaxConn) Commit(wg sync.WaitGroup) sabi.Err { return sabi.Ok() }
-func (conn FooDaxConn) Committed() sabi.Err               { return sabi.Ok() }
-func (conn FooDaxConn) Rollback(wg sync.WaitGroup)        {}
-func (conn FooDaxConn) Close()                            {}
+func (conn FooDaxConn) Commit(wg *sync.WaitGroup) sabi.Err { return sabi.Ok() }
+func (conn FooDaxConn) Committed() sabi.Err                { return sabi.Ok() }
+func (conn FooDaxConn) Rollback(wg *sync.WaitGroup)        {}
+func (conn FooDaxConn) Close()                             {}
 
 type FooDaxSrc struct{}
 
-func (ds FooDaxSrc) SetUp(wg sync.WaitGroup) sabi.Err { return sabi.Ok() }
-func (ds FooDaxSrc) Ready() sabi.Err                  { return sabi.Ok() }
-func (ds FooDaxSrc) End()                             {}
+func (ds FooDaxSrc) SetUp(wg *sync.WaitGroup) sabi.Err { return sabi.Ok() }
+func (ds FooDaxSrc) Ready() sabi.Err                   { return sabi.Ok() }
+func (ds FooDaxSrc) End()                              {}
 func (ds FooDaxSrc) CreateDaxConn() (sabi.DaxConn, sabi.Err) {
 	return FooDaxConn{}, sabi.Ok()
 }

--- a/dax/sabi_0_4_0/tool_test.go
+++ b/dax/sabi_0_4_0/tool_test.go
@@ -1,7 +1,7 @@
 package sabi_0_4_0_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0"
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0"
 )
 
 type FooDaxConn struct{}

--- a/dax/sabi_0_4_0/unlock/benchmark.md
+++ b/dax/sabi_0_4_0/unlock/benchmark.md
@@ -5,7 +5,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	304369935	         3.871 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	42540140	        28.55 ns/op	       0 B/op	       0 allocs/op
@@ -27,7 +27,7 @@ Benchmark_RunTxn_commit_fiveDs-12         	  191293	      6009 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  723151	      1586 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  238455	      4964 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.375s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.375s
 ```
 
 ## original
@@ -35,7 +35,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock	25.375s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0
+pkg: github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddGlobalDaxSrc_oneDs-12        	67004229	        17.56 ns/op	       0 B/op	       0 allocs/op
 Benchmark_AddGlobalDaxSrc_fiveDs-12       	13215918	        91.25 ns/op	       0 B/op	       0 allocs/op
@@ -57,5 +57,5 @@ Benchmark_RunTxn_commit_fiveDs-12         	  187744	      6082 ns/op	    1056 B/
 Benchmark_RunTxn_rollback_oneDs-12        	  726408	      1602 ns/op	     464 B/op	       8 allocs/op
 Benchmark_RunTxn_rollback_fiveDs-12       	  234010	      4990 ns/op	     848 B/op	      24 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0	24.576s
+ok  	github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0	24.576s
 ```

--- a/dax/sabi_0_4_0/unlock/benchmark000_AddGlobalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark000_AddGlobalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_AddGlobalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark010_SetupGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark010_SetupGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_SetupGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark020_FreeGlobalDaxSrcs_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark020_FreeGlobalDaxSrcs_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_FreeGlobalDaxSrcs_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark030_NewDaxBase_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark030_NewDaxBase_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_NewDaxBase(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark040_SetupLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark040_SetupLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_SetupLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark050_FreeLocalDaxSrc_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark050_FreeLocalDaxSrc_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_FreeLocalDaxSrc_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark060_GetDaxConn_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark060_GetDaxConn_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_GetDaxConn_global_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/benchmark070_RunTxn_test.go
+++ b/dax/sabi_0_4_0/unlock/benchmark070_RunTxn_test.go
@@ -1,8 +1,9 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 func Benchmark_RunTxn_commit_oneDs(b *testing.B) {

--- a/dax/sabi_0_4_0/unlock/tool_test.go
+++ b/dax/sabi_0_4_0/unlock/tool_test.go
@@ -1,7 +1,7 @@
 package unlock_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/dax/sabi_0_4_0/unlock"
+	sabi "github.com/sttk/benchmarks_sabi/dax/sabi_0_4_0/unlock"
 )
 
 type FooDaxConn struct{}

--- a/err/benchmark.md
+++ b/err/benchmark.md
@@ -5,7 +5,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/err/go_error
+pkg: github.com/sttk/benchmarks_sabi/err/go_error
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_ok-12                         	1000000000	         0.2459 ns/op	       0 B/op	       0 allocs/op
 Benchmark_ok_isOk-12                    	1000000000	         0.2426 ns/op	       0 B/op	       0 allocs/op
@@ -27,7 +27,7 @@ Benchmark_fiveField_ErrorString-12      	10611986	       113.8 ns/op	      83 B/
 Benchmark_havingCause-12                	35803155	        32.50 ns/op	      16 B/op	       1 allocs/op
 Benchmark_havingCause_ErrorString-12    	27869539	        45.32 ns/op	      48 B/op	       1 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/err/go_error	13.781s
+ok  	github.com/sttk/benchmarks_sabi/err/go_error	13.781s
 ```
 
 ## sabi_err
@@ -35,7 +35,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/err/go_error	13.781s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/err/sabi_err
+pkg: github.com/sttk/benchmarks_sabi/err/sabi_err
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_ok-12                         	1000000000	         0.2428 ns/op	       0 B/op	       0 allocs/op
 Benchmark_ok_isOk-12                    	1000000000	         0.2461 ns/op	       0 B/op	       0 allocs/op
@@ -57,5 +57,5 @@ Benchmark_fiveField_ErrorString-12      	  922323	      1229 ns/op	     536 B/op
 Benchmark_havingCause-12                	251967697	         6.640 ns/op	       0 B/op	       0 allocs/op
 Benchmark_havingCause_ErrorString-12    	 7394916	       163.4 ns/op	     128 B/op	       3 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/err/sabi_err	20.837s
+ok  	github.com/sttk/benchmarks_sabi/err/sabi_err	20.837s
 ```

--- a/err/go_error/benchmark_go_error_test.go
+++ b/err/go_error/benchmark_go_error_test.go
@@ -1,8 +1,9 @@
 package go_error_test
 
 import (
-	"github.com/sttk-go/benchmarks_sabi/err/go_error"
 	"testing"
+
+	"github.com/sttk/benchmarks_sabi/err/go_error"
 )
 
 func unused(v any) {}

--- a/err/sabi_err/benchmark_sabi_err_test.go
+++ b/err/sabi_err/benchmark_sabi_err_test.go
@@ -3,7 +3,7 @@ package sabi_err_test
 import (
 	"testing"
 
-	sabi "github.com/sttk-go/benchmarks_sabi/err/sabi_err"
+	sabi "github.com/sttk/benchmarks_sabi/err/sabi_err"
 )
 
 func unused(v any) {}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sttk-go/benchmarks_sabi
+module github.com/sttk/benchmarks_sabi
 
 go 1.20

--- a/notify/async/benchmark_async_test.go
+++ b/notify/async/benchmark_async_test.go
@@ -1,8 +1,9 @@
 package async_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/notify/async"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/notify/async"
 )
 
 func unused(v any) {}

--- a/notify/benchmark.md
+++ b/notify/benchmark.md
@@ -5,7 +5,7 @@
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/notify/sync
+pkg: github.com/sttk/benchmarks_sabi/notify/sync
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddSyncErrHandler-12    	84087196	        14.95 ns/op	       0 B/op	       0 allocs/op
 Benchmark_ok-12                   	1000000000	         0.2486 ns/op	       0 B/op	       0 allocs/op
@@ -14,7 +14,7 @@ Benchmark_oneFieldReason-12       	 1663237	       742.4 ns/op	     248 B/op	   
 Benchmark_fiveFieldReason-12      	 1550002	       767.6 ns/op	     296 B/op	       3 allocs/op
 Benchmark_havingCauseReason-12    	 1455140	       797.2 ns/op	     248 B/op	       3 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/notify/sync	11.716s
+ok  	github.com/sttk/benchmarks_sabi/notify/sync	11.716s
 ```
 
 ## async
@@ -22,7 +22,7 @@ ok  	github.com/sttk-go/benchmarks_sabi/notify/sync	11.716s
 ```
 goos: darwin
 goarch: amd64
-pkg: github.com/sttk-go/benchmarks_sabi/notify/async
+pkg: github.com/sttk/benchmarks_sabi/notify/async
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark_AddAsyncErrHandler-12    	87209588	        13.57 ns/op	       0 B/op	       0 allocs/op
 Benchmark_ok-12                    	1000000000	         0.2411 ns/op	       0 B/op	       0 allocs/op
@@ -31,5 +31,5 @@ Benchmark_oneFieldReason-12        	 1243851	       962.8 ns/op	     344 B/op	  
 Benchmark_fiveFieldReason-12       	 1226570	       979.6 ns/op	     392 B/op	       4 allocs/op
 Benchmark_havingCauseReason-12     	 1235872	       969.8 ns/op	     344 B/op	       4 allocs/op
 PASS
-ok  	github.com/sttk-go/benchmarks_sabi/notify/async	11.222s
+ok  	github.com/sttk/benchmarks_sabi/notify/async	11.222s
 ```

--- a/notify/sync/benchmark_sync_test.go
+++ b/notify/sync/benchmark_sync_test.go
@@ -1,8 +1,9 @@
 package sync_test
 
 import (
-	sabi "github.com/sttk-go/benchmarks_sabi/notify/sync"
 	"testing"
+
+	sabi "github.com/sttk/benchmarks_sabi/notify/sync"
 )
 
 func unused(v any) {}


### PR DESCRIPTION
This PR changes package path and repository name of this package.

This package was originally in `sttk-go` project, and that package path and repository path were `github.com/sttk-go/benchmarks_sabi`.